### PR TITLE
Add YouTube to Lofi Converter app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,33 @@
-# esfd
+# YouTube to Lofi Converter
 
-This repository is for the `esfd` project.
+This project provides a simple web interface that converts a YouTube video to a lofi-style MP3.
 
-This project is currently under construction. Please check back later for more updates.
+## Requirements
+
+- Python 3.9+
+- Go 1.18+
+- [FFmpeg](https://ffmpeg.org/) installed and available in `PATH`
+- [`yt-dlp`](https://github.com/yt-dlp/yt-dlp) installed and available in `PATH`
+- Python package `gradio`
+
+## Building the Go backend
+
+```
+go build -o lofi-converter lofi_converter.go
+```
+
+## Running the web app
+
+First, install Python dependencies:
+
+```
+pip install gradio
+```
+
+Then launch the Gradio interface:
+
+```
+python app.py
+```
+
+Paste a YouTube URL in the input field and press **Convert** to generate the lofi audio.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,30 @@
+import subprocess
+import gradio as gr
+
+
+def convert(url: str):
+    if not url:
+        return None
+    try:
+        result = subprocess.run([
+            './lofi-converter', url
+        ], capture_output=True, text=True, check=True)
+        output_path = result.stdout.strip().splitlines()[-1]
+        return output_path
+    except subprocess.CalledProcessError as e:
+        return f"Error: {e.stderr}"
+
+
+def main():
+    with gr.Blocks(title="YouTube to Lofi Converter") as demo:
+        gr.Markdown("# YouTube to Lofi Converter")
+        url_in = gr.Textbox(label="YouTube URL")
+        convert_btn = gr.Button("Convert")
+        audio_out = gr.Audio(label="Lofi Output")
+
+        convert_btn.click(fn=convert, inputs=url_in, outputs=audio_out)
+    demo.launch()
+
+
+if __name__ == "__main__":
+    main()

--- a/lofi_converter.go
+++ b/lofi_converter.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func check(err error) {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: lofi-converter <youtube url>")
+		os.Exit(1)
+	}
+	url := os.Args[1]
+
+	tmpDir, err := ioutil.TempDir("", "lofi")
+	check(err)
+	defer os.RemoveAll(tmpDir)
+
+	inputPath := filepath.Join(tmpDir, "input.m4a")
+	outputPath := filepath.Join(tmpDir, "output.mp3")
+
+	// Download audio using yt-dlp
+	cmdYt := exec.Command("yt-dlp", "-f", "bestaudio", "-o", inputPath, url)
+	cmdYt.Stdout = os.Stdout
+	cmdYt.Stderr = os.Stderr
+	err = cmdYt.Run()
+	check(err)
+
+	// Lofi filter chain for ffmpeg
+	filter := "atempo=0.9,lowpass=f=5000,highpass=f=150,aecho=0.8:0.9:1000:0.3"
+
+	cmdFfmpeg := exec.Command("ffmpeg", "-y", "-i", inputPath, "-af", filter, outputPath)
+	cmdFfmpeg.Stdout = os.Stdout
+	cmdFfmpeg.Stderr = os.Stderr
+	err = cmdFfmpeg.Run()
+	check(err)
+
+	fmt.Println(outputPath)
+}


### PR DESCRIPTION
## Summary
- add a Go CLI app `lofi_converter.go` that downloads audio via yt-dlp and processes it with ffmpeg
- create a simple Gradio interface in `app.py`
- document requirements and usage in the README

## Testing
- `python3 -m py_compile app.py`
- `go build -o lofi-converter lofi_converter.go`
- `./lofi-converter` *(prints usage)*

------